### PR TITLE
Automate the release assets generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+run-name: Generate release assets for v${{ github.event.release.tag_name }}
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  package-and-upload:
+    name: Package and upload release assets
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repo
+      - uses: actions/checkout@v5
+      # Package add-on
+      - name: Create Elephant add-on fda package
+        run: |
+          mkdir ./dist
+          (cd ./plugin && zip -r ../dist/elephant.fda .)
+      # Upload release assets
+      - name: Upload packaged add-on to release v${{ github.event.release.tag_name }}
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./dist/*


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to automate the `elephant.fda` package generation and upload process.

The action will trigger immediately once a new release is created. This workflow runs very quickly, taking only about 7 seconds to finish.

The justification for automating this process is that it makes the output package downloaded by the user more trustworthy because it's generated on a GitHub Actions runner rather than a local device. Plus, it's less hassle for the maintainers. 😉

> [!IMPORTANT] 
You need to enable GitHub Actions on your repository for this workflow to become active before the next release. You also need to enable **"Read and write permissions"** in **"Workflow permissions"** so the action is allowed to upload assets to a release.
